### PR TITLE
Use the full version to download

### DIFF
--- a/net-im/linux-c7-zoom/Makefile
+++ b/net-im/linux-c7-zoom/Makefile
@@ -1,9 +1,9 @@
 # $FreeBSD$
 
 PORTNAME=	zoom
-PORTVERSION=	3.5
+PORTVERSION=	3.5.385850.0413
 CATEGORIES=	net-im linux
-MASTER_SITES=	https://zoom.us/client/latest/
+MASTER_SITES=	https://zoom.us/client/${PORTVERSION}/
 PKGNAMEPREFIX=	linux-c7-
 DISTFILES=	${PORTNAME}_x86_64.rpm
 SRC_DISTFILES=

--- a/net-im/linux-c7-zoom/distinfo
+++ b/net-im/linux-c7-zoom/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1586701202
-SHA256 (centos/zoom_x86_64.rpm) = 6a823ffd282134f283ca23db09f77b986ce7fa7fe07092eff7849763ac31e62f
-SIZE (centos/zoom_x86_64.rpm) = 71321020
+TIMESTAMP = 1586892288
+SHA256 (centos/zoom_x86_64.rpm) = 1c8adff2f752c015e7c1ca51b5cb673580e53f81f4e67747fef137a1b7fbc801
+SIZE (centos/zoom_x86_64.rpm) = 71674296


### PR DESCRIPTION
Using the full version numbering, we can directly download the rpm from zoom.